### PR TITLE
Juniper Config - Add Peer-Group Type

### DIFF
--- a/Juniper.conf
+++ b/Juniper.conf
@@ -62,6 +62,7 @@ set multihop
 # OPTIONAL - use only if you're not sourcing from physical interface (erase everything before/including the forward slash ->) / set local-address <IP address>
 set export AllowNothing
 set import PTON-Blackhole
+set type external
 
 # Commit 
 top


### PR DESCRIPTION
Define peer-group type as external (type external).